### PR TITLE
Refactor broker into modular components with tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +368,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +384,12 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -413,6 +441,7 @@ dependencies = [
  "env_logger",
  "log",
  "serde",
+ "tempfile",
  "thiserror",
  "zmq",
 ]
@@ -480,6 +509,19 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.3",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "ryu"
@@ -587,6 +629,19 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ config = { version = "0.15.14", default-features = false, features = [
     "toml",
     "json",
 ] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,99 @@
+use serde::Deserialize;
+use std::path::Path;
+use thiserror::Error;
+
+#[derive(Debug, Deserialize)]
+pub struct Settings {
+    pub pairs: Vec<Pair>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Pair {
+    /// Optional label shown in logs
+    pub name: Option<String>,
+    /// Bind XSUB here (publishers connect)
+    pub frontend: String,
+    /// Bind XPUB here (subscribers connect)
+    pub backend: String,
+    /// XSUB receive high-water mark
+    #[serde(default = "default_hwm")]
+    pub xsub_rcvhwm: i32,
+    /// XPUB send high-water mark
+    #[serde(default = "default_hwm")]
+    pub xpub_sndhwm: i32,
+}
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("configuration load error: {0}")]
+    Load(#[from] config::ConfigError),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid configuration: {0}")]
+    Invalid(String),
+}
+
+pub fn default_hwm() -> i32 {
+    100_000
+}
+
+pub fn load_settings() -> Result<Settings, ConfigError> {
+    let cwd = std::env::current_dir()?;
+    load_settings_from(&cwd)
+}
+
+pub fn load_settings_from<P: AsRef<Path>>(dir: P) -> Result<Settings, ConfigError> {
+    let dir = dir.as_ref();
+    let cfg = config::Config::builder()
+        .add_source(config::File::from(dir.join("proxy.yaml")).required(false))
+        .add_source(config::File::from(dir.join("proxy.toml")).required(false))
+        .add_source(config::File::from(dir.join("proxy.json")).required(false))
+        .build()?;
+
+    let settings: Settings = cfg.try_deserialize()?;
+    if settings.pairs.is_empty() {
+        return Err(ConfigError::Invalid("no pairs defined".into()));
+    }
+    Ok(settings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_hwm_is_100k() {
+        assert_eq!(default_hwm(), 100_000);
+    }
+
+    #[test]
+    fn load_settings_from_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = r#"
+            pairs:
+              - name: default
+                frontend: "tcp://*:5557"
+                backend: "tcp://*:5558"
+        "#;
+        std::fs::write(dir.path().join("proxy.yaml"), yaml).unwrap();
+
+        let settings = load_settings_from(dir.path()).unwrap();
+        assert_eq!(settings.pairs.len(), 1);
+        let pair = &settings.pairs[0];
+        assert_eq!(pair.xsub_rcvhwm, default_hwm());
+        assert_eq!(pair.xpub_sndhwm, default_hwm());
+    }
+
+    #[test]
+    fn error_on_empty_pairs() {
+        let dir = tempfile::tempdir().unwrap();
+        let yaml = "pairs: []";
+        std::fs::write(dir.path().join("proxy.yaml"), yaml).unwrap();
+
+        let err = load_settings_from(dir.path()).unwrap_err();
+        match err {
+            ConfigError::Invalid(msg) => assert_eq!(msg, "no pairs defined"),
+            _ => panic!("unexpected error: {err}"),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,63 +1,24 @@
+mod config;
+mod proxy;
+
+use crate::config::load_settings;
+use crate::proxy::run_pair;
 use log::{error, info};
-use serde::Deserialize;
 use std::thread;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-enum ProxyError {
-    #[error("configuration load error: {0}")]
-    ConfigLoad(#[from] config::ConfigError),
-    #[error("ZeroMQ error: {0}")]
-    Zmq(#[from] zmq::Error),
-    #[error("invalid configuration: {0}")]
-    Config(String),
+enum BrokerError {
+    #[error(transparent)]
+    Config(#[from] config::ConfigError),
 }
 
-#[derive(Debug, Deserialize)]
-struct Settings {
-    pairs: Vec<Pair>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-struct Pair {
-    /// Optional label shown in logs
-    name: Option<String>,
-    /// Bind XSUB here (publishers connect)
-    frontend: String,
-    /// Bind XPUB here (subscribers connect)
-    backend: String,
-    /// XSUB receive high-water mark
-    #[serde(default = "default_hwm")]
-    xsub_rcvhwm: i32,
-    /// XPUB send high-water mark
-    #[serde(default = "default_hwm")]
-    xpub_sndhwm: i32,
-}
-
-fn default_hwm() -> i32 {
-    100_000
-}
-
-fn main() -> Result<(), ProxyError> {
-    // Initialize logging: set RUST_LOG=info (or debug, trace, …) to control verbosity.
+fn main() -> Result<(), BrokerError> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
-    // Load configuration from proxy.{yaml|toml|json} in the current dir.
-    // The first existing file among these will be used (they're all optional).
-    let cfg = config::Config::builder()
-        .add_source(config::File::new("proxy", config::FileFormat::Yaml).required(false))
-        .add_source(config::File::new("proxy", config::FileFormat::Toml).required(false))
-        .add_source(config::File::new("proxy", config::FileFormat::Json).required(false))
-        .build()?;
-
-    let settings: Settings = cfg.try_deserialize()?;
-    if settings.pairs.is_empty() {
-        return Err(ProxyError::Config("no pairs defined".into()));
-    }
-
+    let settings = load_settings()?;
     info!("loaded {} pair(s)", settings.pairs.len());
 
-    // One thread per pair; each runs a blocking built-in proxy.
     let mut handles = Vec::with_capacity(settings.pairs.len());
     for (i, pair) in settings.pairs.into_iter().enumerate() {
         let label = pair
@@ -68,10 +29,10 @@ fn main() -> Result<(), ProxyError> {
             "[{label}] XSUB bind: {}  |  XPUB bind: {}  |  HWM(rx,tx)=({}, {})",
             pair.frontend, pair.backend, pair.xsub_rcvhwm, pair.xpub_sndhwm
         );
-
+        let handle_label = label.clone();
         handles.push(thread::spawn(move || {
-            if let Err(e) = run_pair(&label, pair) {
-                error!("[{label}] error: {e}");
+            if let Err(e) = run_pair(&handle_label, pair) {
+                error!("[{handle_label}] error: {e}");
             }
         }));
     }
@@ -79,27 +40,5 @@ fn main() -> Result<(), ProxyError> {
     for h in handles {
         let _ = h.join();
     }
-    Ok(())
-}
-
-fn run_pair(label: &str, pair: Pair) -> Result<(), ProxyError> {
-    let ctx = zmq::Context::new();
-    let xsub = ctx.socket(zmq::XSUB)?;
-    let xpub = ctx.socket(zmq::XPUB)?;
-
-    xsub.set_rcvhwm(pair.xsub_rcvhwm)?;
-    xpub.set_sndhwm(pair.xpub_sndhwm)?;
-
-    xsub.bind(&pair.frontend)?;
-    xpub.bind(&pair.backend)?;
-
-    info!("[{label}] ready; forwarding with zmq::proxy()");
-    // Blocks until interrupted or an error occurs.
-    zmq::proxy(&xsub, &xpub)?;
-
-    // Best-effort cleanup if proxy ever returns.
-    xsub.set_linger(0).ok();
-    xpub.set_linger(0).ok();
-
     Ok(())
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,0 +1,46 @@
+use crate::config::Pair;
+use log::info;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ProxyError {
+    #[error("ZeroMQ error: {0}")]
+    Zmq(#[from] zmq::Error),
+}
+
+pub fn run_pair(label: &str, pair: Pair) -> Result<(), ProxyError> {
+    let ctx = zmq::Context::new();
+    let xsub = ctx.socket(zmq::XSUB)?;
+    let xpub = ctx.socket(zmq::XPUB)?;
+
+    xsub.set_rcvhwm(pair.xsub_rcvhwm)?;
+    xpub.set_sndhwm(pair.xpub_sndhwm)?;
+
+    xsub.bind(&pair.frontend)?;
+    xpub.bind(&pair.backend)?;
+
+    info!("[{label}] ready; forwarding with zmq::proxy()");
+    zmq::proxy(&xsub, &xpub)?;
+
+    xsub.set_linger(0).ok();
+    xpub.set_linger(0).ok();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_pair_invalid_endpoint() {
+        let pair = Pair {
+            name: None,
+            frontend: "bad".to_string(),
+            backend: "bad".to_string(),
+            xsub_rcvhwm: 1,
+            xpub_sndhwm: 1,
+        };
+        let err = run_pair("test", pair).unwrap_err();
+        assert!(matches!(err, ProxyError::Zmq(_)));
+    }
+}


### PR DESCRIPTION
## Summary
- modularize configuration loading and define `ConfigError`
- split ZeroMQ proxy logic into its own module
- cover configuration parsing and error cases with unit tests

## Testing
- `cargo fmt -- --check`
- `cargo clippy --tests -- -Dwarnings`
- `cargo build --verbose`
- `cargo test --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68ab6a394c74832a959ccabb9e149f16